### PR TITLE
implement definition of Hash#slice method

### DIFF
--- a/ext/fast_slice/fast_slice.c
+++ b/ext/fast_slice/fast_slice.c
@@ -1,9 +1,11 @@
 #include <ruby.h>
 
+static VALUE FastSlice = Qnil;
+
 // Effectively a copy and paste from hash.c
 // but replacing RHASH(hash)->tbl with RHASH_TBL (RHASH is not public)
-VALUE
-__rb_hash_has_key(VALUE hash, VALUE key)
+static VALUE
+rb_hash_has_key(VALUE hash, VALUE key)
 {
   if (!RHASH_TBL(hash))
     return Qfalse;
@@ -13,12 +15,9 @@ __rb_hash_has_key(VALUE hash, VALUE key)
   return Qfalse;
 }
 
-VALUE
-rb_fast_slice(int argc, VALUE *argv, VALUE self)
+static VALUE
+fast_slice(VALUE hash, VALUE keys)
 {
-  VALUE hash, args;
-  rb_scan_args(argc, argv, "1*", &hash, &args);
-
   if (TYPE(hash) != T_HASH) {
     rb_raise(rb_eTypeError, "expected a Hash");
     return Qfalse;
@@ -29,11 +28,11 @@ rb_fast_slice(int argc, VALUE *argv, VALUE self)
     result = rb_hash_new();
 
     int i;
-    for (i=0; i < RARRAY_LEN(args); i++) {
-      VALUE arg;
-      arg = rb_ary_entry(args, i);
-      if(__rb_hash_has_key(hash, arg) == Qtrue) {
-        rb_hash_aset(result, arg, rb_hash_aref(hash, arg));
+    for (i=0; i < RARRAY_LEN(keys); i++) {
+      VALUE key;
+      key = rb_ary_entry(keys, i);
+      if(rb_hash_has_key(hash, key) == Qtrue) {
+        rb_hash_aset(result, key, rb_hash_aref(hash, key));
       }
     }
 
@@ -43,20 +42,33 @@ rb_fast_slice(int argc, VALUE *argv, VALUE self)
   return rb_hash_dup(hash);
 }
 
-// Add the `slice` instance method to Hash
-// TODO figure out how to do this
-VALUE rb_define_hash_slice(int argc, VALUE *argv, VALUE self)
+VALUE
+rb_fast_slice_m(int argc, VALUE *argv, VALUE self)
 {
-  rb_define_method(rb_cHash, "slice", rb_fast_slice, -1);
+  VALUE hash, args;
+  rb_scan_args(argc, argv, "1*", &hash, &args);
+  return fast_slice(hash, args);
+}
 
+VALUE
+rb_fast_slice(int argc, VALUE *argv, VALUE self)
+{
+  VALUE args;
+  rb_scan_args(argc, argv, "0*", &args);
+  return fast_slice(self, args);
+}
+
+static VALUE
+rb_define_hash_slice_m(void)
+{
+  rb_prepend_module(rb_cHash, FastSlice);
   return Qtrue;
 }
 
 void Init_fast_slice( void )
 {
-  VALUE FastSlice = Qnil;
-  FastSlice = rb_define_class_under(rb_cObject, "FastSlice", rb_cObject);
-      
-  rb_define_singleton_method(FastSlice, "slice", rb_fast_slice, -1);
-  // rb_define_singleton_method(FastSlice, "define_on_hash", rb_define_hash_slice, 0);
+  FastSlice = rb_define_module_under(rb_cObject, "FastSlice");
+  rb_define_singleton_method(FastSlice, "slice", rb_fast_slice_m, -1);
+  rb_define_method(FastSlice, "slice", rb_fast_slice, -1);
+  rb_define_singleton_method(FastSlice, "define_on_hash", rb_define_hash_slice_m, 0);
 }


### PR DESCRIPTION
* control visibility of private functions by making them static
* move FastSlice to a static global variable
* change FastSlice to be a module instead of a class
* implement replacing Hash#slice by prepending the FastSlice module
* extract core logic of both the singleton and instance methods for slice to a static function